### PR TITLE
minor fix for insert

### DIFF
--- a/protocol/TwoPLPasha/TwoPLPasha.h
+++ b/protocol/TwoPLPasha/TwoPLPasha.h
@@ -431,7 +431,7 @@ template <class Database> class TwoPLPasha {
                                         // make the placeholder as valid
                                         std::atomic<uint64_t> *meta = table->search_metadata(key);      // cannot use cached row
                                         DCHECK(meta != nullptr);
-                                        TwoPLPashaHelper::modify_tuple_valid_bit(*meta, true);
+                                        twopl_pasha_global_helper->modify_tuple_valid_bit(*meta, true, true);
                                 } else {
                                         auto coordinatorID = partitioner.master_coordinator(partitionId);
                                         txn.network_size += MessageFactoryType::new_remote_insert_message(
@@ -472,7 +472,7 @@ template <class Database> class TwoPLPasha {
                                         for (auto i = 0u; i < scan_results.size(); i++) {
                                                 char *cxl_row = reinterpret_cast<char *>(scan_results[i].meta);
                                                 DCHECK(cxl_row != nullptr);
-                                                TwoPLPashaHelper::remote_modify_tuple_valid_bit(cxl_row, false);
+                                                twopl_pasha_global_helper->remote_modify_tuple_valid_bit(cxl_row, false);
                                                 // TwoPLPashaHelper::decrease_reference_count_via_ptr(cxl_row);
                                                 txn.network_size += MessageFactoryType::new_remote_delete_message(*messages[coordinatorID], *table, scan_results[i].key);
                                         }
@@ -493,7 +493,7 @@ template <class Database> class TwoPLPasha {
                                         auto key = insertKey.get_key();
                                         std::atomic<uint64_t> *meta = table->search_metadata(key);      // cannot use cached row
                                         DCHECK(meta != nullptr);
-                                        TwoPLPashaHelper::modify_tuple_valid_bit(*meta, true);
+                                        twopl_pasha_global_helper->modify_tuple_valid_bit(*meta, true, true);
                                 } else {
                                         // does not support remote insert & delete
                                         DCHECK(0);

--- a/protocol/TwoPLPasha/TwoPLPashaHelper.h
+++ b/protocol/TwoPLPasha/TwoPLPashaHelper.h
@@ -1121,6 +1121,8 @@ out_unlock_lmeta:
                         }
 
                         if (is_insert == true) {
+                                // prepare read to avoid CHECK fault in finish_write
+                                scc_manager->prepare_read(smeta, coordinator_id, scc_data, sizeof(TwoPLPashaSharedDataSCC));
                                 scc_manager->finish_write(smeta, coordinator_id, scc_data, sizeof(TwoPLPashaSharedDataSCC));
                         }
                         smeta->unlock();
@@ -1146,6 +1148,8 @@ out_unlock_lmeta:
                 }
 
                 if (is_insert == true) {
+                        // prepare read to avoid CHECK fault in finish_write
+                        scc_manager->prepare_read(smeta, coordinator_id, scc_data, sizeof(TwoPLPashaSharedDataSCC));
                         scc_manager->finish_write(smeta, coordinator_id, scc_data, sizeof(TwoPLPashaSharedDataSCC));
                 }
                 smeta->unlock();

--- a/protocol/TwoPLPasha/TwoPLPashaMessage.h
+++ b/protocol/TwoPLPasha/TwoPLPashaMessage.h
@@ -623,7 +623,7 @@ class TwoPLPashaMessageHandler {
                 auto key = insertKey.get_key();
                 CXLTableBase *target_cxl_table = twopl_pasha_global_helper->get_cxl_table(table_id, partition_id);
                 char *cxl_row = reinterpret_cast<char *>(target_cxl_table->search(key));
-                TwoPLPashaHelper::remote_modify_tuple_valid_bit(cxl_row, true);
+                twopl_pasha_global_helper->remote_modify_tuple_valid_bit(cxl_row, true, true);
 
                 // record it locally
                 insertKey.set_inserted_cxl_row(cxl_row);


### PR DESCRIPTION
This PR fixes a software cache coherence (SCC) bug related to modifying the `is_valid` bit in insert operations.

### Issue

The `is_valid` bit is stored in `scc_data` within the CXL shared memory region. According to the SCC protocol, modifications to `scc_data` must be followed by `scc_manager->finish_write()` to clear `SWcc-bitmap` and flush dirty cachelines.

For rows with write locks, `finish_write()` is correctly called during lock release. However, **insert operations do not hold write locks on the inserted placeholder rows**. When committing inserts, `modify_tuple_valid_bit()` and 'remote_modify_tuple_valid_bit()' set the `is_valid` bit to true without calling `finish_write()`, violating SCC consistency.

### Changes

**Modified functions in `TwoPLPashaHelper.h`:**
- `modify_tuple_valid_bit()` and `remote_modify_tuple_valid_bit()`
  - Added `is_insert` parameter (default: false)
  - Call `scc_manager->finish_write()` when `is_insert == true`
  - Changed from static to non-static member functions to access the `coordinator_id`

**Updated call sites:**
- `TwoPLPasha.h`: Pass `is_insert=true` when committing inserts
- `TwoPLPashaMessage.h`: Pass `is_insert=true` for remote insert responses

These changes ensure SCC consistency for insert operations while maintaining existing behavior for delete and update operations (which already have proper `finish_write()` calls via lock release).

These fixes are minor and do **not** affect the conclusions of the paper, since the original TPC-C benchmark do not perform insert operations over shared data regions.