### PR TITLE
Fix CXL B+Tree page-size accounting

### DIFF
--- a/common/btree_olc_cxl/BTreeOLC_CXL.h
+++ b/common/btree_olc_cxl/BTreeOLC_CXL.h
@@ -862,7 +862,7 @@ class BPlusTree {
 		 */
 		BTreeLeaf *split(KeyType &sep)
 		{
-                        char *base = reinterpret_cast<char *>(star::cxl_memory.cxlalloc_malloc_wrapper(sizeof(BTreeLeaf), star::CXLMemory::INDEX_ALLOCATION));
+                        char *base = reinterpret_cast<char *>(star::cxl_memory.cxlalloc_malloc_wrapper(LeafPageSize, star::CXLMemory::INDEX_ALLOCATION));
 			BTreeLeaf *newLeaf = new (base) BTreeLeaf(); // Placement new
 
 			newLeaf->setCount(this->getCount() - (this->getCount() / 2));
@@ -905,7 +905,7 @@ class BPlusTree {
 			sep = keys_[this->getCount() - 1].deepCopy();
 		}
 	};
-	// static_assert(LeafPageSize > sizeof(BTreeLeaf), "LeafPageSize too small");
+	static_assert(LeafPageSize >= sizeof(BTreeLeaf), "LeafPageSize too small");
 
 	/**
 	 * BTreeInner - inner node


### PR DESCRIPTION
When a leaf node was created by `BTreeLeaf::split()`,
`cxlalloc_malloc_wrapper()` increased the CXL index-memory usage counter by
`sizeof(BTreeLeaf)`. When the leaf node was later merged and retired,
`cxlalloc_free_wrapper()` decreased the same counter by `kLeafPageSize`.

These values are not necessarily equal. In the current YCSB build,
`sizeof(BTreeLeaf)` is 3416 bytes, while the leaf page size is 4096 bytes.
Therefore, retiring a split leaf can subtract 680 more bytes than were
recorded during its allocation, resulting in inaccurate memory statistics and
potential unsigned-counter underflow.

The impact is limited to memory accounting. It does not affect B+Tree
correctness or actual memory reclamation because `cxlalloc_free()` only takes
the allocation pointer.

This change allocates split leaf pages using `LeafPageSize` and adds a
compile-time check to ensure that `LeafPageSize` is large enough to hold
`BTreeLeaf`.